### PR TITLE
about: use bot.get_all_members()

### DIFF
--- a/dog/ext/about.py
+++ b/dog/ext/about.py
@@ -43,7 +43,7 @@ class About(Cog):
             .strip().decode('utf-8')
 
         if self.maker is None:
-            self.maker = await self.bot.get_user_info(owner_id)
+            self.maker = discord.utils.get(self.bot.get_all_members(), id=owner_id)
 
         embed = discord.Embed(
             title='Dogbot',


### PR DESCRIPTION
Since `get_user_info` still wastes 1 API call before caching, we can use `bot.get_all_members` that uses the client's cache which is already filled up when the bot is ready 👌 